### PR TITLE
Test case name must be consistent with directory name

### DIFF
--- a/benchconf/all.yaml
+++ b/benchconf/all.yaml
@@ -1,4 +1,4 @@
-integer_underflow_and_overflow/overflow_add:
+integer_overflow_and_underflow/overflow_add:
   ignore: false
   issues: 
   - address: 139


### PR DESCRIPTION
Noticed that test case name differs from directory where solidity file is located. It makes config invalid for analyser tool to execute this benchmark.